### PR TITLE
Fixes crash when loading episodes list is unsuccessful 

### DIFF
--- a/RT_Stream_App/Models/MainModel.cs
+++ b/RT_Stream_App/Models/MainModel.cs
@@ -156,8 +156,7 @@ namespace RT_Stream_App.Models
             }
             catch (Exception)
             {
-
-                return default(TOut);
+                throw;
             }
 
             TOut toReturn = JsonConvert.DeserializeObject<TOut>(response.Content.ReadAsStringAsync().Result);


### PR DESCRIPTION
When looking over the program for my other main project (Seeing how I implemented HttpClient) I found that one of the try catches was different, this has been fixed in this PR