### PR TITLE
Security fix

### DIFF
--- a/RT_Stream_App/Models/MainModel.cs
+++ b/RT_Stream_App/Models/MainModel.cs
@@ -98,14 +98,6 @@ namespace RT_Stream_App.Models
             }
         }
 
-        public static void aesKeyLoad()
-        {
-            if (!File.Exists(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"))
-            {
-                File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json", EncryptProvider.CreateAesKey().Key);
-            }
-        }
-
         /// <summary>
         /// Saves the amount of episodes to load per page when the value is changed
         /// </summary>

--- a/RT_Stream_App/Models/MainModel.cs
+++ b/RT_Stream_App/Models/MainModel.cs
@@ -31,6 +31,26 @@ namespace RT_Stream_App.Models
         /// <returns></returns>
         public static settings SettingsLoad()
         {
+            if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"))
+            {
+                // Only for next release to transition from the old method to the new one
+                if (File.Exists(settingFile))
+                {
+                    settings newSettings = JsonConvert.DeserializeObject<settings>(File.ReadAllText(settingFile));
+                    if (!String.IsNullOrWhiteSpace(newSettings.username) || !String.IsNullOrWhiteSpace(newSettings.password))
+                    {
+                        string username = EncryptProvider.AESDecrypt(newSettings.username, File.ReadAllText(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"));
+                        string password = EncryptProvider.AESDecrypt(newSettings.password, File.ReadAllText(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"));
+                        newSettings.username = encryptDetails(newSettings.username);
+                        newSettings.password = encryptDetails(newSettings.password);
+                        File.WriteAllText(settingFile, JsonConvert.SerializeObject(newSettings));
+                    }
+                }
+                
+                File.Delete(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json");
+                
+            }
+
             if (File.Exists(settingFile))
             {
                 return JsonConvert.DeserializeObject<settings>(File.ReadAllText(settingFile));
@@ -435,7 +455,7 @@ namespace RT_Stream_App.Models
             }
             else
             {
-                return EncryptProvider.AESEncrypt(detail, File.ReadAllText(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"));
+                return EncryptProvider.AESEncrypt(detail, getAESKey());
             }
         }
 
@@ -447,8 +467,20 @@ namespace RT_Stream_App.Models
             }
             else
             {
-                return EncryptProvider.AESDecrypt(detail, File.ReadAllText(AppDomain.CurrentDomain.BaseDirectory + "RT_Stream_App.applicationcfg.json"));
+                return EncryptProvider.AESDecrypt(detail, getAESKey());
             }
+        }
+
+        /// <summary>
+        /// Generates a key based on the computer name and user without storing the key on disk
+        /// </summary>
+        /// <returns></returns>
+        public static string getAESKey()
+        {
+            string keyString = "";
+            keyString += Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+            keyString += Environment.UserName;
+            return EncryptProvider.Sha256(keyString).Substring(0,32);
         }
 
         /// <summary>

--- a/RT_Stream_App/ViewModels/MainWindowViewModel.cs
+++ b/RT_Stream_App/ViewModels/MainWindowViewModel.cs
@@ -52,7 +52,6 @@ namespace RT_Stream_App.ViewModels
             VideoToken = VideoTokenSource.Token;
             LoadVideo = new DelegateCommand(() => LoadVideoAsync());
             OpenVideo = new DelegateCommand(async () => await LoadVideoPlayerAsync(VideoToken));
-            MainModel.aesKeyLoad();
             LoginTmp = new DelegateCommand(() => SaveLoginTmp());
             LoginSave = new DelegateCommand(() => SaveLogin());
             LoginAlready = false;


### PR DESCRIPTION
This change removed the use of keeping a private API key on the disk. 

Instead of using a file, it pulls from the system, using the computer name and username to generate a key, this key is then used for encryption/decryption.

Pros:
* A lot safer
* Doesn't require a file to encrypt or decrypt

Cons:
* Only works for a single user on a single computer
* Portable setups make saving usernames and passwords impossible if used on more than one device

This will be merged, likely tomorrow with a release shortly following