### PR TITLE
Fixed loading the Stream Player

### DIFF
--- a/RT_Stream_App/ViewModels/MainWindowViewModel.cs
+++ b/RT_Stream_App/ViewModels/MainWindowViewModel.cs
@@ -406,7 +406,7 @@ namespace RT_Stream_App.ViewModels
                 {
                     ProcessStartInfo psi = new ProcessStartInfo
                     {
-                        FileName = AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.exe",
+                        FileName = AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.exe ../VideoLink.m3u8",
                         UseShellExecute = true
                     };
                     await Task.Run(() => Process.Start(psi));
@@ -414,7 +414,7 @@ namespace RT_Stream_App.ViewModels
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     // Currently bugged when publishing from Visual Studio, use the dotnet publish command instead
-                    await Task.Run(() => Process.Start(AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player"));
+                    await Task.Run(() => Process.Start(AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.AppImage ../VideoLink.m3u8"));
                 }
             }
             else

--- a/RT_Stream_App/ViewModels/MainWindowViewModel.cs
+++ b/RT_Stream_App/ViewModels/MainWindowViewModel.cs
@@ -406,15 +406,21 @@ namespace RT_Stream_App.ViewModels
                 {
                     ProcessStartInfo psi = new ProcessStartInfo
                     {
-                        FileName = AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.exe ../VideoLink.m3u8",
+                        FileName = AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.exe",
+                        Arguments = "\"" + AppDomain.CurrentDomain.BaseDirectory + "VideoLink.m3u8 \"",
                         UseShellExecute = true
                     };
                     await Task.Run(() => Process.Start(psi));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
+                    ProcessStartInfo psi = new ProcessStartInfo
+                    {
+                        FileName = AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.AppImage",
+                        Arguments = "\"" + AppDomain.CurrentDomain.BaseDirectory + "VideoLink.m3u8\""
+                    };
                     // Currently bugged when publishing from Visual Studio, use the dotnet publish command instead
-                    await Task.Run(() => Process.Start(AppDomain.CurrentDomain.BaseDirectory + "rt-stream-player/rt-stream-player.AppImage ../VideoLink.m3u8"));
+                    await Task.Run(() => Process.Start(psi));
                 }
             }
             else


### PR DESCRIPTION
The new use of the [Electron Stream Player](https://github.com/2haloes/Electron-Stream-Player) which replaces the RT Stream Player was bugged hard in the last PR for both Windows and Linux.

This fixes those issues