### PR TITLE
Updated the video stream extraction to allow use with the newer CDN

### DIFF
--- a/RT_Stream_App/Models/MainModel.cs
+++ b/RT_Stream_App/Models/MainModel.cs
@@ -23,7 +23,7 @@ namespace RT_Stream_App.Models
         public const string siteURL = "https://svod-be.roosterteeth.com";
         public const string loginURL = "https://auth.roosterteeth.com/oauth/token";
         public static readonly string settingFile = (AppDomain.CurrentDomain.BaseDirectory + "settings.json");
-        public static string[] qualityList => new string[] { "240", "360", "480", "720", "1080", "4K" };
+        public static string[] qualityList => new string[] { "270", "360", "540", "720", "1080", "4K" };
 
         /// <summary>
         /// Loads the settings (Or creates the settings file on first load)
@@ -270,7 +270,7 @@ namespace RT_Stream_App.Models
             {
                 return null;
             }
-            File.WriteAllLines(AppDomain.CurrentDomain.BaseDirectory + "VideoLink.m3u8", streamFile);
+            File.WriteAllLines(AppDomain.CurrentDomain.BaseDirectory + "VideoLink.m3u8", fileToOpen);
             return toReturn;
         }
 
@@ -386,7 +386,7 @@ namespace RT_Stream_App.Models
             List<string> compList = new List<string>();
 
             // NOTE: I actually have no idea if the 4k is correct. It's borderline impossible to find a video with 4K
-            if (compList.Any(item => item.Contains(qualityList[qualityToken])))
+            if (fileContent.Any(item => item.Contains(qualityList[qualityToken])))
             {
                 for (int i = 0; i < fileContent.Count; i++)
                 {
@@ -394,27 +394,12 @@ namespace RT_Stream_App.Models
                     {
                         compList.Add(fileContent[i]);
 
-                        if (fileContent[i].Contains("-STREAM-INF"))
+                        if (fileContent[i].Contains("X-STREAM-INF"))
                         {
                             compList.Add(fileContent[i + 1]);
 
                             i++;
                         }
-                    }
-                }
-            }
-            else if (qualityToken == 0 && compList.Any(item => item.Contains("238")))
-            {
-                for (int i = 0; i < fileContent.Count; i++)
-                {
-                    if (fileContent[i].Contains("x" + qualityList[qualityToken] + ",") || fileContent[i].Contains("x238,"))
-                    {
-                        continue;
-                    }
-                    else if (fileContent[i].Contains("-STREAM-INF"))
-                    {
-                        fileContent.RemoveRange(i, 2);
-                        i--;
                     }
                 }
             }

--- a/RT_Stream_App/ViewModels/MainWindowViewModel.cs
+++ b/RT_Stream_App/ViewModels/MainWindowViewModel.cs
@@ -28,7 +28,7 @@ namespace RT_Stream_App.ViewModels
             appSettings = MainModel.SettingsLoad();
             ThemeList = MainModel.ThemesLoad();
             selectedTheme = ThemeList[appSettings.theme];
-            QualityList = new ObservableCollection<string>() { "240", "360", "480", "720", "1080", "4K" };
+            QualityList = new ObservableCollection<string>() { "270", "360", "540", "720", "1080", "4K" };
             selectedQuality = QualityList[appSettings.quality];
             Username = MainModel.decryptDetails(appSettings.username);
             Password = MainModel.decryptDetails(appSettings.password);


### PR DESCRIPTION
This is a small rewrite of the stream extractor, instead of grabbing the m3u8 file to stream directly from (the old way of doing it) the existing m3u8 stream file is pulled apart to get the correct quality.

This change was made for a couple of reasons, first, the whole point of the app is moot if this doesn't work, second, the audio streams are now stored seperately within the master m3u8 file.

The current state of the branch means that the resolution options in the program that match what Rooster Teeth use (i.e 1080p) will work fine, further work needs to be done for some other options (i.e. 540p)

I may add more resolution options to reduce the number of hacks as this rewrite has resulted in a lot of clean up in that area of the code (not intentionally, I was focused on getting it working).

I would also like to reduce the number of audio streams provided to the player to one, it shouldn't be too hard to do though.

This change appears to change player compatablity:

Confirmed not working:

- VLC
- MPV

Confirmed working:

- MPC-HC (assuming anything MPC based will also work)
- FFPlay

Requires testing:

- Electron Stream App
- Gnome video